### PR TITLE
Raise RecordNotSaved if aggregated model fails to save

### DIFF
--- a/HornsAndHooves-moribus.gemspec
+++ b/HornsAndHooves-moribus.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name        = "HornsAndHooves-moribus"
   s.version     = Moribus::VERSION
   s.authors     = ["HornsAndHooves", "Artem Kuzko", "Sergey Potapov"]
-  s.email       = ["a.kuzko@gmail.com", "blake131313@gmail.com"]
+  s.email       = ["arthur.shagall@gmail.com", "a.kuzko@gmail.com", "blake131313@gmail.com"]
   s.homepage    = "https://github.com/HornsAndHooves/moribus"
   s.licenses    = ["MIT"]
   s.summary     = %q{Introduces Aggregated and Tracked behavior to ActiveRecord::Base models}

--- a/lib/moribus/aggregated_behavior.rb
+++ b/lib/moribus/aggregated_behavior.rb
@@ -48,8 +48,15 @@ module Moribus
 
     # Bang version of #save.
     def save!(*args)
-      save(*args) or raise ActiveRecord::RecordNotSaved
+      save(*args) or raise_record_not_saved_error
     end
+
+    # Raise record not saved
+    def raise_record_not_saved_error
+      args = Rails::VERSION::MINOR < 2 ? [] : ["Failed to save record"]
+      raise ActiveRecord::RecordNotSaved, *args
+    end
+    private :raise_record_not_saved_error
 
     # Use the +lookup_relation+ to get the very first existing record that
     # corresponds to +self+.

--- a/spec/moribus_spec.rb
+++ b/spec/moribus_spec.rb
@@ -189,6 +189,14 @@ describe Moribus do
       expect(name.id).to eq @existing.id
     end
 
+    it "raises the expected error when 'save!' fails" do
+      name = SpecPersonName.create :first_name => "Alice", :last_name => "Smith"
+      name.last_name = nil
+      expect {
+        name.save!
+      }.to raise_error(ActiveRecord::RecordNotSaved)
+    end
+
     context "with caching" do
       before do
         @existing = SpecCustomerFeature.create(:feature_name => "Pays")


### PR DESCRIPTION
In Rails 4.2, ActiveRecord::RecordNotSaved requires a message to be passed in.