### PR TITLE
support Ruby 3.1

### DIFF
--- a/lib/moribus/alias_association.rb
+++ b/lib/moribus/alias_association.rb
@@ -45,7 +45,7 @@ module Moribus
         options = scope if scope.is_a?(Hash)
 
         alias_name = options.delete(:alias)
-        reflection = super(name, scope, options, &extension)
+        reflection = super(name, scope, **options, &extension)
         alias_association(alias_name, name) if alias_name
         reflection
       end
@@ -55,7 +55,7 @@ module Moribus
         options = scope if scope.is_a?(Hash)
 
         alias_name = options.delete(:alias)
-        reflection = super(name, scope, options)
+        reflection = super(name, scope, **options)
         alias_association(alias_name, name) if alias_name
         reflection
       end

--- a/lib/moribus/macros.rb
+++ b/lib/moribus/macros.rb
@@ -91,7 +91,7 @@ module Moribus
         scope = current_scope
       end
 
-      reflection = has_one(name, scope, options)
+      reflection = has_one(name, scope, **options)
       reflection = normalize_reflection(reflection, name)
       reflection.options[:is_current] = true
       accepts_nested_attributes_for name
@@ -106,7 +106,7 @@ module Moribus
     # by special aggregated functionality (attribute delegation. See
     # Extensions::HasAggregatedExtension)
     def has_aggregated(name, options = {})
-      reflection = belongs_to(name, options)
+      reflection = belongs_to(name, **options)
       reflection = normalize_reflection(reflection, name)
       reflection.options[:aggregated] = true
       accepts_nested_attributes_for name


### PR DESCRIPTION
Make some modifications to the invocations of methods in `ActiveRecord::Associations` to more closely align with the signatures in the Rails source. This also fixes some bugs in this gem when running Rails 6 with Ruby 3.1, where [using the last argument as keyword parameters is no longer supported](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) (as of Ruby 3.0).

Here are some links to the source of Rails 5 and 6 to see that the invocations now match the signatures of the ActiveRecord methods:
- Rails 6.1.6.1
  - [`ActiveRecord::Base.has_many`](https://github.com/rails/rails/blob/v6.1.6.1/activerecord/lib/active_record/associations.rb#L1457)
  - [`ActiveRecord::Base.belongs_to`](https://github.com/rails/rails/blob/v6.1.6.1/activerecord/lib/active_record/associations.rb#L1761)
  - [`ActiveRecord::Base.has_one`](https://github.com/rails/rails/blob/v6.1.6.1/activerecord/lib/active_record/associations.rb#L1607)
- Rails 5.2.8.1
  - [`ActiveRecord::Base.has_many`](https://github.com/rails/rails/blob/v5.2.8.1/activerecord/lib/active_record/associations.rb#L1368)
  - [`ActiveRecord::Base.belongs_to`](https://github.com/rails/rails/blob/v5.2.8.1/activerecord/lib/active_record/associations.rb#L1653)
  - [`ActiveRecord::Base.has_one`](https://github.com/rails/rails/blob/v5.2.8.1/activerecord/lib/active_record/associations.rb#L1507)