### PR TITLE
Update info's updated_at on setting is_current to false

### DIFF
--- a/lib/moribus/extensions/has_current_extension.rb
+++ b/lib/moribus/extensions/has_current_extension.rb
@@ -6,15 +6,27 @@ module Moribus
       # Sets 'is_current' flag of overridden record to false, instead
       # of deleting it or setting foreign key to nil.
       def remove_target!(*)
+        # Use custom update to avoid running ActiveRecord optimistic locking
+        # and to avoid updating lock_version column:
+        klass = target.class
+
         if target.new_record?
           target.is_current = false
+          target.updated_at = Time.zone.now if klass.column_names.include?("updated_at")
         else
-          # Use custom update to avoid running ActiveRecord optimistic locking
-          # and to avoid updating lock_version column:
-          klass = target.class
-
           sql =  "UPDATE #{klass.quoted_table_name} " \
                  "SET \"is_current\" = #{klass.connection.quote(false)} "
+
+          if klass.column_names.include?("updated_at")
+            now = case ActiveRecord::Base.connection.adapter_name
+                  when "SQLite"     then "datetime('now')"
+                  # :nocov:
+                  when "PostgreSQL" then "NOW()"
+                  # :nocov:
+                  end
+            sql << %{, "updated_at" = #{now} } if now
+          end
+
           sql << "WHERE #{klass.quoted_primary_key} = " \
                  "#{klass.connection.quote(target.send(klass.primary_key))} "
 

--- a/lib/moribus/extensions/has_current_extension.rb
+++ b/lib/moribus/extensions/has_current_extension.rb
@@ -8,30 +8,26 @@ module Moribus
       def remove_target!(*)
         # Use custom update to avoid running ActiveRecord optimistic locking
         # and to avoid updating lock_version column:
-        klass = target.class
-
         if target.new_record?
           target.is_current = false
-          target.updated_at = Time.zone.now if klass.column_names.include?("updated_at")
+          target.updated_at = Time.zone.now if has_updated_at_column?
         else
+          klass = target.class
+
           sql =  "UPDATE #{klass.quoted_table_name} " \
                  "SET \"is_current\" = #{klass.connection.quote(false)} "
 
-          if klass.column_names.include?("updated_at")
-            now = case ActiveRecord::Base.connection.adapter_name
-                  when "SQLite"     then "datetime('now')"
-                  # :nocov:
-                  when "PostgreSQL" then "NOW()"
-                  # :nocov:
-                  end
-            sql << %{, "updated_at" = #{now} } if now
-          end
+          sql << %{, "updated_at" = #{klass.connection.quote(Time.zone.now)} } if has_updated_at_column?
 
           sql << "WHERE #{klass.quoted_primary_key} = " \
                  "#{klass.connection.quote(target.send(klass.primary_key))} "
 
           klass.connection.update sql
         end
+      end
+
+      private def has_updated_at_column?
+        target.class.column_names.include?("updated_at")
       end
     end
   end

--- a/lib/moribus/extensions/has_current_extension.rb
+++ b/lib/moribus/extensions/has_current_extension.rb
@@ -26,6 +26,9 @@ module Moribus
         end
       end
 
+      # Is the record has a column with name `updated_at`
+      #
+      # @return [Boolean]
       private def has_updated_at_column?
         target.class.column_names.include?("updated_at")
       end

--- a/spec/moribus/extensions/has_current_extension_spec.rb
+++ b/spec/moribus/extensions/has_current_extension_spec.rb
@@ -38,7 +38,7 @@ describe Moribus::Extensions::HasCurrentExtension do
       it "sets 'is_current' flag of overridden record to false for new record" do
         old_info = customer.spec_customer_info
         customer.spec_customer_info = SpecCustomerInfo.new
-        expect(old_info.is_current).to be_falsey
+        expect(old_info.is_current).to be false
       end
 
       it "sets 'is_current' flag updates updated_at column" do

--- a/spec/moribus/extensions/has_current_extension_spec.rb
+++ b/spec/moribus/extensions/has_current_extension_spec.rb
@@ -16,6 +16,7 @@ describe Moribus::Extensions::HasCurrentExtension do
 
     class SpecCustomer < MoribusSpecModel(spec_status_id: :integer)
       has_one_current :spec_customer_info, inverse_of: :spec_customer, dependent: :destroy
+      delegate_associated :previous_id, to: :spec_customer_info
     end
   end
 
@@ -24,17 +25,45 @@ describe Moribus::Extensions::HasCurrentExtension do
   end
 
   let(:customer) { SpecCustomer.create }
-  let!(:info)    { SpecCustomerInfo.create(spec_customer: customer, is_current: true) }
+  let!(:info) do
+    SpecCustomerInfo.create(spec_customer: customer, is_current: true, created_at: 1.hour.ago, updated_at: 1.hour.ago)
+  end
 
   describe ".remove_target!" do
-    before do
-      allow(customer.spec_customer_info).to receive(:new_record?).and_return(true)
+    context "new record" do
+      before do
+        allow(customer.spec_customer_info).to receive(:new_record?).and_return(true)
+      end
+
+      it "sets 'is_current' flag of overridden record to false for new record" do
+        old_info = customer.spec_customer_info
+        customer.spec_customer_info = SpecCustomerInfo.new
+        expect(old_info.is_current).to be_falsey
+      end
+
+      it "sets 'is_current' flag updates updated_at column" do
+        old_info = customer.spec_customer_info
+        customer.spec_customer_info = SpecCustomerInfo.new
+        expect(old_info.updated_at >= old_info.created_at + 1.hour).to be true
+      end
     end
 
-    it "sets 'is_current' flag of overridden record to false for new record" do
-      old_info = customer.spec_customer_info
-      customer.spec_customer_info = SpecCustomerInfo.new
-      expect(old_info.is_current).to be_falsey
+    context "persisted record" do
+      it "sets 'is_current' flag updates updated_at column" do
+        old_info = customer.spec_customer_info
+        customer.spec_customer_info = SpecCustomerInfo.new
+        old_info.reload
+        # I use 59 minutes instead of hour because there can be small difference in milliseconds
+        expect(old_info.updated_at >= old_info.created_at + 59.minutes).to be true
+      end
+
+      it "sets 'is_current' flag updates updated_at column" do
+        old_info = customer.spec_customer_info
+        customer.update!(previous_id: 123)
+        old_info.reload
+        # I use 59 minutes instead of hour because there can be small difference in milliseconds
+        expect(old_info.updated_at >= old_info.created_at + 59.minutes).to be true
+      end
     end
   end
 end


### PR DESCRIPTION
We should maintain the `updated_at` column properly on updates.