### PR TITLE
More support for Ruby 3.1

### DIFF
--- a/lib/moribus/aggregated_behavior.rb
+++ b/lib/moribus/aggregated_behavior.rb
@@ -26,7 +26,7 @@ module Moribus
     # the lookup succeeds, we don't want the original #save to be executed.
     # But if +false+ is returned by the callback, it will also be returned
     # by the #save method, wrongly indicating the result of saving.
-    def save(*)
+    def save(**)
       @updated_as_aggregated = false
       run_callbacks(:save) do
         return (lookup_self_and_replace or super) if new_record?
@@ -47,8 +47,8 @@ module Moribus
     end
 
     # Bang version of #save.
-    def save!(*args)
-      save(*args) or raise_record_not_saved_error
+    def save!(**kwargs)
+      save(**kwargs) or raise_record_not_saved_error
     end
 
     # Raise "record not saved".

--- a/spec/moribus_spec.rb
+++ b/spec/moribus_spec.rb
@@ -30,7 +30,7 @@ describe Moribus do
                                             middle_name:    :string,
                                             last_name:      :string,
                                             spec_suffix_id: :integer
-    )
+                                          )
       acts_as_aggregated non_content_columns: :middle_name
       has_enumerated :spec_suffix, default: ""
 
@@ -47,16 +47,16 @@ describe Moribus do
     end
 
     class SpecCustomerInfo < MoribusSpecModel(
-      spec_customer_id:    :integer!,
-      spec_person_name_id: :integer,
-      spec_status_id:      :integer,
-      spec_type_id:        :integer,
-      is_current:          :boolean,
-      lock_version:        :integer,
-      created_at:          :datetime,
-      updated_at:          :datetime,
-      previous_id:         :integer
-    )
+                                        spec_customer_id:    :integer!,
+                                        spec_person_name_id: :integer,
+                                        spec_status_id:      :integer,
+                                        spec_type_id:        :integer,
+                                        is_current:          :boolean,
+                                        lock_version:        :integer,
+                                        created_at:          :datetime,
+                                        updated_at:          :datetime,
+                                        previous_id:         :integer
+                              )
       attr :custom_field
 
       belongs_to :spec_customer, inverse_of: :spec_customer_info, touch: true
@@ -68,14 +68,14 @@ describe Moribus do
     end
 
     class SpecCustomerInfoWithType < MoribusSpecModel(
-      spec_customer_id: :integer!,
-      spec_status_id:   :integer,
-      spec_type_id:     :integer,
-      is_current:       :boolean,
-      lock_version:     :integer,
-      created_at:       :datetime,
-      updated_at:       :datetime
-    )
+                                        spec_customer_id: :integer!,
+                                        spec_status_id:   :integer,
+                                        spec_type_id:     :integer,
+                                        is_current:       :boolean,
+                                        lock_version:     :integer,
+                                        created_at:       :datetime,
+                                        updated_at:       :datetime
+                                      )
       attr :custom_field
 
       belongs_to :spec_customer, inverse_of: :spec_customer_info_with_type, touch: true
@@ -97,7 +97,7 @@ describe Moribus do
                                                email:            :string,
                                                is_current:       :boolean,
                                                status:           :string
-    )
+                                              )
       connection.add_index table_name, [:email, :is_current], unique: true
 
       belongs_to :spec_customer
@@ -190,7 +190,7 @@ describe Moribus do
                                         email:         "foo@bar.com",
                                         status:        "unverified",
                                         is_current:    true
-      )
+                                      )
       expect{ email.update!(status: "verified") }.not_to raise_error
     end
 

--- a/spec/moribus_spec.rb
+++ b/spec/moribus_spec.rb
@@ -30,7 +30,7 @@ describe Moribus do
                                             middle_name:    :string,
                                             last_name:      :string,
                                             spec_suffix_id: :integer
-                                          )
+    )
       acts_as_aggregated non_content_columns: :middle_name
       has_enumerated :spec_suffix, default: ""
 
@@ -47,16 +47,16 @@ describe Moribus do
     end
 
     class SpecCustomerInfo < MoribusSpecModel(
-                                        spec_customer_id:    :integer!,
-                                        spec_person_name_id: :integer,
-                                        spec_status_id:      :integer,
-                                        spec_type_id:        :integer,
-                                        is_current:          :boolean,
-                                        lock_version:        :integer,
-                                        created_at:          :datetime,
-                                        updated_at:          :datetime,
-                                        previous_id:         :integer
-                              )
+      spec_customer_id:    :integer!,
+      spec_person_name_id: :integer,
+      spec_status_id:      :integer,
+      spec_type_id:        :integer,
+      is_current:          :boolean,
+      lock_version:        :integer,
+      created_at:          :datetime,
+      updated_at:          :datetime,
+      previous_id:         :integer
+    )
       attr :custom_field
 
       belongs_to :spec_customer, inverse_of: :spec_customer_info, touch: true
@@ -68,14 +68,14 @@ describe Moribus do
     end
 
     class SpecCustomerInfoWithType < MoribusSpecModel(
-                                        spec_customer_id: :integer!,
-                                        spec_status_id:   :integer,
-                                        spec_type_id:     :integer,
-                                        is_current:       :boolean,
-                                        lock_version:     :integer,
-                                        created_at:       :datetime,
-                                        updated_at:       :datetime
-                                      )
+      spec_customer_id: :integer!,
+      spec_status_id:   :integer,
+      spec_type_id:     :integer,
+      is_current:       :boolean,
+      lock_version:     :integer,
+      created_at:       :datetime,
+      updated_at:       :datetime
+    )
       attr :custom_field
 
       belongs_to :spec_customer, inverse_of: :spec_customer_info_with_type, touch: true
@@ -97,7 +97,7 @@ describe Moribus do
                                                email:            :string,
                                                is_current:       :boolean,
                                                status:           :string
-                                              )
+    )
       connection.add_index table_name, [:email, :is_current], unique: true
 
       belongs_to :spec_customer
@@ -190,7 +190,7 @@ describe Moribus do
                                         email:         "foo@bar.com",
                                         status:        "unverified",
                                         is_current:    true
-                                      )
+      )
       expect{ email.update!(status: "verified") }.not_to raise_error
     end
 

--- a/spec/support/moribus_spec_model.rb
+++ b/spec/support/moribus_spec_model.rb
@@ -47,8 +47,7 @@ def MoribusSpecModel(column_definition = {})
               end
               options[:default] = 0 if name == :lock_version
               args = [type, name]
-              args << options unless options.empty?
-              t.send(*args)
+              t.send(*args, **options)
             end
           end
         end


### PR DESCRIPTION
- Changes "save" to better align with the definition in the Rails 6 source.
- Fixes MoribusSpecModel not recognizing column options in Ruby 3

Before this PR, many specs were failing in Ruby 3, because [using the last argument as keyword parameters is no longer supported](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). After this PR, all specs pass in both Ruby 2.3.3 and Ruby 3.1.3.

Rails 6's save:
[ActiveRecord::Base.save](https://github.com/rails/rails/blob/v6.1.6.1/activerecord/lib/active_record/persistence.rb#L473)

Rails 5's save:
[ActiveRecord::Base.save](https://github.com/rails/rails/blob/v5.2.8.1/activerecord/lib/active_record/persistence.rb#L274)